### PR TITLE
Remove mandatory variable Definitions and allow access token in header

### DIFF
--- a/client/lib/src/client.dart
+++ b/client/lib/src/client.dart
@@ -12,8 +12,9 @@ class RestClient extends http.BaseClient {
   http.Client _client;
   String _endpoint;
   Uri _baseUri;
+  String _authToken;
 
-  RestClient(this._endpoint) {
+  RestClient(this._endpoint, this._authToken) {
     this._client = new http.Client();
     this._baseUri = Uri.parse(this._endpoint);
   }
@@ -45,7 +46,12 @@ class RestClient extends http.BaseClient {
     String body = toJson(data);
     Uri uri = _baseUri.replace(path: _baseUri.path + path);
     http.Response response = await this.post(uri.toString(),
-        body: body, headers: {'Content-Type': 'application/json'});
+        body: body,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': _authToken
+        }
+      );
     return handleJsonResponse(response);
   }
 
@@ -85,7 +91,7 @@ class RestClient extends http.BaseClient {
 }
 
 class GraphqlClient extends RestClient {
-  GraphqlClient(String endpoint) : super(endpoint);
+  GraphqlClient(String endpoint, String authToken) : super(endpoint, authToken);
 
   Future<JsonResponse> request<T>(
       String query, Map<String, dynamic> variables) async {
@@ -118,7 +124,8 @@ main() async {
       }
     }""";
   GraphqlClient cli = new GraphqlClient(
-      "http://localhost:60000/simple/v1/cj9mldxkd008c017544mu2vhw");
+      "http://localhost:60000/simple/v1/cj9mldxkd008c017544mu2vhw",
+      "token 4476588976a53d2ceb1d7bfaf94e41bb056ecad4");
   var result = await cli.request(query, {"alias": "atest"});
   print(result);
 }

--- a/client/lib/src/client.dart
+++ b/client/lib/src/client.dart
@@ -125,7 +125,7 @@ main() async {
     }""";
   GraphqlClient cli = new GraphqlClient(
       "http://localhost:60000/simple/v1/cj9mldxkd008c017544mu2vhw",
-      "token 4476588976a53d2ceb1d7bfaf94e41bb056ecad4");
+      "test token");
   var result = await cli.request(query, {"alias": "atest"});
   print(result);
 }

--- a/generator/lib/src/GraphqlSetting.dart
+++ b/generator/lib/src/GraphqlSetting.dart
@@ -8,9 +8,10 @@ GraphqlBuildSetting createSetting(
     {String schemaUrl,
       String method: "post",
       bool postIntrospectionQuery: true,
-      String schemaFile}) {
-  return new GraphqlBuildSetting(
-      schemaUrl, method, postIntrospectionQuery, schemaFile);
+      String schemaFile,
+      String authToken
+      }) {
+  return new GraphqlBuildSetting(schemaUrl, method, postIntrospectionQuery, schemaFile, authToken);
 }
 
 class GraphqlBuildSetting {
@@ -18,12 +19,13 @@ class GraphqlBuildSetting {
 
   String schemaUrl;
   String method;
+  String authToken;
   bool postIntrospectionQuery;
 
   String schemaFile;
 
   GraphqlBuildSetting(this.schemaUrl, this.method, this.postIntrospectionQuery,
-      this.schemaFile);
+      this.schemaFile, this.authToken);
 
   dynamic _schemaObject = null;
 
@@ -34,7 +36,7 @@ class GraphqlBuildSetting {
         var fileContent = await new File(schemaFile).readAsString();
         _schemaObject = new JsonObject.fromJsonString(fileContent);
       } else if (schemaUrl != null) {
-        var client = new RestClient(this.schemaUrl);
+        var client = new RestClient(this.schemaUrl, this.authToken);
         log.info("fetching schema from url:${this.schemaUrl}");
         JsonResponse result;
         if (method == "post") {

--- a/generator/lib/src/Operation.dart
+++ b/generator/lib/src/Operation.dart
@@ -27,9 +27,12 @@ class Operation extends BaseTypes {
   generateCode(String resultClass) {
     Reference graphqlQuery =
         refer("GraphqlQuery", "package:graphql_fetch/graphql_fetch.dart");
-    List<String> variables = _context.variableDefinitions.variableDefinitions
+    List<String> variables = [];
+    if (_context.variableDefinitions != null) {
+      variables = _context.variableDefinitions.variableDefinitions
         .map((v) => '"${v.variable.name}": ${v.variable.name}')
         .toList();
+    }
     String query = wrapStringCode(_context.span.text);
 
     List<String> strings = _queryTypes.depFragments.map((r) => "${r
@@ -39,7 +42,7 @@ class Operation extends BaseTypes {
       return "const query = $query;"
           "return new ${a(graphqlQuery)}("
           "${strings.join(" + ")},"
-          "{${variables.join(',')}},"
+          "${variables.length> 1 ? variables.join(','): null},"
           "${resultClass}.fromMap);";
     });
   }
@@ -54,7 +57,6 @@ class Operation extends BaseTypes {
     b.body.add(cls);
     return resultClassName;
   }
-
   generateReturn(FileBuilder b) {
     for (SelectionContext sel in _context.selectionSet.selections) {
       String field = sel.field.fieldName.name;


### PR DESCRIPTION
For queries which don't require variables the code was breaking as `_context.variableDefinitions` would be null and upon reading `variableDefinitions` would throw error. 

Adding following checks:-

1. Reading `variableDefinitions` only if `_context.variableDefinitions` is present.
2. If variables is set then assigning to final query else assigning null

Auth token changes:-

1. allowing option to pass auth token in the api calls.
